### PR TITLE
Add option for `--binary-files`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ jobs:
 
               syntax: extended
 
+              binary-files: without-match
+
               paths:
                 - "**/*"
 
@@ -88,6 +90,13 @@ Array of Objects with the following keys:
   The `grep` "Pattern Syntax" to use. This corresponds to `grep`'s `-E`, `F`,
   `-G`, or `-P` options. One of `extended`, `fixed`, `basic`, or `perl`. Default
   is `basic` (like `grep` itself).
+
+- `binary-files`
+
+  Controls searching in binary files, corresponding to `grep`'s 
+  `--binary-files=<value>` option. One of `binary` (search binary files but do
+  not print), `without-match` (do not search binary files), or `text` (treat
+  all files as text). Default is `binary` (like `grep` itself).
 
 - `paths`
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Array of Objects with the following keys:
 
 - `binary-files`
 
-  Controls searching in binary files, corresponding to `grep`'s 
+  Controls searching in binary files, corresponding to `grep`'s
   `--binary-files=<value>` option. One of `binary` (search binary files but do
   not print), `without-match` (do not search binary files), or `text` (treat
   all files as text). Default is `binary` (like `grep` itself).

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,9 +32,11 @@ var minimatch_1 = __nccwpck_require__(3973);
 function fromPatternYaml(patternYaml) {
     var pattern = patternYaml.pattern, syntax = patternYaml.syntax, paths = patternYaml.paths, level = patternYaml.level, title = patternYaml.title, message = patternYaml.message;
     var pathsIgnore = patternYaml["paths-ignore"];
+    var binaryFiles = patternYaml["binary-files"];
     return {
         pattern: pattern,
         syntax: syntax || "basic",
+        binaryFiles: binaryFiles || "binary",
         paths: paths || ["**/*"],
         pathsIgnore: pathsIgnore || [],
         level: level || "notice",
@@ -280,11 +282,22 @@ function grepSyntaxOption(syntax) {
             return "--perl-regexp";
     }
 }
-function grep(syntax, pattern, files, silent) {
+function grepBinaryFilesOption(syntax) {
+    switch (syntax) {
+        case "binary":
+            return "--binary-files=binary";
+        case "without-match":
+            return "--binary-files=without-match";
+        case "text":
+            return "--binary-files=text";
+    }
+}
+function grep(pattern, files, _a) {
+    var syntax = _a.syntax, binaryFiles = _a.binaryFiles, _b = _a.silent, silent = _b === void 0 ? false : _b;
     return __awaiter(this, void 0, void 0, function () {
         var stdout, grepArgs;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
+        return __generator(this, function (_c) {
+            switch (_c.label) {
                 case 0:
                     stdout = "";
                     files.push("/dev/null");
@@ -292,6 +305,7 @@ function grep(syntax, pattern, files, silent) {
                         "--line-number",
                         "--color=never",
                         grepSyntaxOption(syntax),
+                        grepBinaryFilesOption(binaryFiles),
                         pattern,
                     ].concat(files);
                     return [4, exec.exec("grep", grepArgs, {
@@ -301,10 +315,10 @@ function grep(syntax, pattern, files, silent) {
                                 },
                             },
                             ignoreReturnCode: true,
-                            silent: silent || false,
+                            silent: silent,
                         })];
                 case 1:
-                    _a.sent();
+                    _c.sent();
                     return [2, parseGrep(stdout)];
             }
         });
@@ -474,7 +488,10 @@ function run() {
                                     return [4, getFiles(onlyChanged, changedFiles, pattern)];
                                 case 1:
                                     files = _c.sent();
-                                    return [4, (0, grep_1.grep)(pattern.syntax, pattern.pattern, files)];
+                                    return [4, (0, grep_1.grep)(pattern.pattern, files, {
+                                            syntax: pattern.syntax,
+                                            binaryFiles: pattern.binaryFiles,
+                                        })];
                                 case 2:
                                     results = _c.sent();
                                     core.info("Grepped ".concat(files.length, " file(s) => ").concat(results.length, " result(s)"));

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -63,6 +63,19 @@ test("Respects syntax", () => {
   expect(results[0].syntax).toEqual("perl");
 });
 
+test("Respects binary-files", () => {
+  const example = [
+    "- pattern: abc",
+    "  binary-files: without-match",
+    "  title: Found abc",
+  ].join("\n");
+
+  const results = config.loadPatterns(example);
+
+  expect(results.length).toBe(1);
+  expect(results[0].binaryFiles).toEqual("without-match");
+});
+
 test("Respects paths-ignore", () => {
   const example = [
     "- pattern: abc",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,6 @@
 import * as config from "./config";
 import type { AnnotationLevel } from "./github";
-import type { GrepSyntax } from "./grep";
+import type { GrepSyntax, GrepBinaryFiles } from "./grep";
 
 test("Loads minimal Patterns", () => {
   const example = [
@@ -16,6 +16,7 @@ test("Loads minimal Patterns", () => {
     {
       pattern: "abc",
       syntax: "basic",
+      binaryFiles: "binary",
       paths: ["**/*"],
       pathsIgnore: [],
       level: "notice",
@@ -25,6 +26,7 @@ test("Loads minimal Patterns", () => {
     {
       pattern: "xyz",
       syntax: "basic",
+      binaryFiles: "binary",
       paths: ["**/*"],
       pathsIgnore: [],
       level: "notice",
@@ -94,6 +96,7 @@ test("matchesAny", () => {
   const pattern = {
     pattern: "",
     syntax: "basic" as GrepSyntax,
+    binaryFiles: "binary" as GrepBinaryFiles,
     paths: ["**/*.js", "**/README.md"],
     pathsIgnore: ["**/*.test.js", "test/**/*"],
     level: "notice" as AnnotationLevel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,11 +15,11 @@ export type Pattern = {
   message: string | null;
 };
 
-
 function fromPatternYaml(patternYaml: PatternYaml): Pattern {
-  const { pattern, syntax, binaryFiles, paths, level, title, message } =
+  const { pattern, syntax, paths, level, title, message } =
     patternYaml;
   const pathsIgnore = patternYaml["paths-ignore"];
+  const binaryFiles = patternYaml["binary-files"];
 
   return {
     pattern,

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,7 @@ export type Pattern = {
 };
 
 function fromPatternYaml(patternYaml: PatternYaml): Pattern {
-  const { pattern, syntax, paths, level, title, message } =
-    patternYaml;
+  const { pattern, syntax, paths, level, title, message } = patternYaml;
   const pathsIgnore = patternYaml["paths-ignore"];
   const binaryFiles = patternYaml["binary-files"];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,11 +2,12 @@ import * as yaml from "js-yaml";
 import { Minimatch } from "minimatch";
 
 import type { AnnotationLevel } from "./github";
-import type { GrepSyntax } from "./grep";
+import type { GrepSyntax, GrepBinaryFiles } from "./grep";
 
 export type Pattern = {
   pattern: string;
   syntax: GrepSyntax;
+  binaryFiles: GrepBinaryFiles;
   paths: string[];
   pathsIgnore: string[];
   level: AnnotationLevel;
@@ -14,13 +15,16 @@ export type Pattern = {
   message: string | null;
 };
 
+
 function fromPatternYaml(patternYaml: PatternYaml): Pattern {
-  const { pattern, syntax, paths, level, title, message } = patternYaml;
+  const { pattern, syntax, binaryFiles, paths, level, title, message } =
+    patternYaml;
   const pathsIgnore = patternYaml["paths-ignore"];
 
   return {
     pattern,
     syntax: syntax || "basic",
+    binaryFiles: binaryFiles || "binary",
     paths: paths || ["**/*"],
     pathsIgnore: pathsIgnore || [],
     level: level || "notice",
@@ -32,6 +36,7 @@ function fromPatternYaml(patternYaml: PatternYaml): Pattern {
 type PatternYaml = {
   pattern: string;
   syntax: GrepSyntax | null;
+  "binary-files": GrepBinaryFiles | null;
   paths: string[] | null;
   "paths-ignore": string[] | null;
   level: AnnotationLevel | null;

--- a/src/grep.test.ts
+++ b/src/grep.test.ts
@@ -10,7 +10,7 @@ async function grepLines(
 ): Promise<number[]> {
   const file = "/tmp/grep-action-test-grep.txt";
   fs.writeFileSync(file, lines.join("\n"));
-  const results = await grep(syntax, pattern, [file], true);
+  const results = await grep(syntax, "binary", pattern, [file], true);
   return results.map((r) => r.line);
 }
 

--- a/src/grep.test.ts
+++ b/src/grep.test.ts
@@ -10,7 +10,11 @@ async function grepLines(
 ): Promise<number[]> {
   const file = "/tmp/grep-action-test-grep.txt";
   fs.writeFileSync(file, lines.join("\n"));
-  const results = await grep(syntax, "binary", pattern, [file], true);
+  const results = await grep(pattern, [file], {
+    syntax,
+    binaryFiles: "binary",
+    silent: true,
+  });
   return results.map((r) => r.line);
 }
 

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -15,6 +15,19 @@ function grepSyntaxOption(syntax: GrepSyntax): string {
   }
 }
 
+export type GrepBinaryFiles = "binary" | "without-match" | "text";
+
+function grepBinaryFilesOption(syntax: GrepBinaryFiles): string {
+  switch (syntax) {
+    case "binary":
+      return "--binary-files=binary";
+    case "without-match":
+      return "--binary-files=without-match";
+    case "text":
+      return "--binary-files=text";
+  }
+}
+
 export type GrepResult = {
   input: string;
   path: string;
@@ -23,6 +36,7 @@ export type GrepResult = {
 
 export async function grep(
   syntax: GrepSyntax,
+  binaryFiles: GrepBinaryFiles,
   pattern: string,
   files: string[],
   silent?: boolean
@@ -36,6 +50,7 @@ export async function grep(
     "--line-number",
     "--color=never",
     grepSyntaxOption(syntax),
+    grepBinaryFilesOption(binaryFiles),
     pattern,
   ].concat(files);
 

--- a/src/grep.ts
+++ b/src/grep.ts
@@ -34,12 +34,16 @@ export type GrepResult = {
   line: number;
 };
 
+type GrepOptions = {
+  syntax: GrepSyntax;
+  binaryFiles: GrepBinaryFiles;
+  silent?: boolean;
+};
+
 export async function grep(
-  syntax: GrepSyntax,
-  binaryFiles: GrepBinaryFiles,
   pattern: string,
   files: string[],
-  silent?: boolean
+  { syntax, binaryFiles, silent = false }: GrepOptions
 ): Promise<GrepResult[]> {
   let stdout = "";
 
@@ -61,7 +65,7 @@ export async function grep(
       },
     },
     ignoreReturnCode: true,
-    silent: silent || false,
+    silent,
   });
 
   return parseGrep(stdout);

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,12 +71,10 @@ async function run() {
     for (const pattern of patterns) {
       core.startGroup(`grep "${pattern.pattern}"`);
       const files = await getFiles(onlyChanged, changedFiles, pattern);
-      const results = await grep(
-        pattern.syntax,
-        pattern.binaryFiles,
-        pattern.pattern,
-        files
-      );
+      const results = await grep(pattern.pattern, files, {
+        syntax: pattern.syntax,
+        binaryFiles: pattern.binaryFiles,
+      });
 
       core.info(
         `Grepped ${files.length} file(s) => ${results.length} result(s)`

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,12 @@ async function run() {
     for (const pattern of patterns) {
       core.startGroup(`grep "${pattern.pattern}"`);
       const files = await getFiles(onlyChanged, changedFiles, pattern);
-      const results = await grep(pattern.syntax, pattern.pattern, files);
+      const results = await grep(
+        pattern.syntax,
+        pattern.binaryFiles,
+        pattern.pattern,
+        files
+      );
 
       core.info(
         `Grepped ${files.length} file(s) => ${results.length} result(s)`


### PR DESCRIPTION
This is used in CodeClimate's FIXME engine when it uses `grep` and seems like a reasonable option to have in this workflow. The default for `grep` is `--binary-files=binary` so that is preserved here.

Not sure how to go about testing this.