### PR TITLE
Stop creating a new check to store our annotations

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -6,6 +6,9 @@ restylers:
   - prettier:
       image:
         tag: v2.5.1
+      command:
+        - prettier
+        - --write
       include:
         - "src/**/*.ts"
   - whitespace:

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -4,6 +4,8 @@ restylers:
   - jq:
       enabled: false # prefer prettier-json
   - prettier:
+      image:
+        tag: v2.5
       include:
         - "src/**/*.ts"
   - whitespace:

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -5,7 +5,7 @@ restylers:
       enabled: false # prefer prettier-json
   - prettier:
       image:
-        tag: v2.5
+        tag: v2.5.1
       include:
         - "src/**/*.ts"
   - whitespace:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ jobs:
 
   **NOTE**: This action doesn't really work on non-`pull_request` events.
 
+- `create-new-check`: If `true`, a new Check is created and the annotations are
+  attached to it. Default is `false`, which means to log the annotations
+  normally.
+
+- `failure-threshold`: If any annotations are created at or above this level,
+  the run will fail. See `patterns[].level` for valid values. Default is
+  `failure`.
+
 - `github-token`: override the default `GITHUB_TOKEN`, if desired.
 
 See [`./action.yml`](./action.yml) for complete details.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
               title: A brief title
 
               message: |
-               A longer message body
+                A longer message body
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Only operate on changed files"
     required: true
     default: "true"
+  create-new-check:
+    description: "Create a new Check for our annotations?"
+    required: true
+    default: "false"
   github-token:
     description: "Override GitHub token, if necessary"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Create a new Check for our annotations?"
     required: true
     default: "false"
+  failure-threshold:
+    description: "Fail on any annotations at or above this level"
+    required: true
+    default: "failure"
   github-token:
     description: "Override GitHub token, if necessary"
     required: true

--- a/src/github.ts
+++ b/src/github.ts
@@ -31,15 +31,12 @@ export type AnnotationLevel = "notice" | "warning" | "failure";
 export async function createCheck(
   client: ClientType,
   name: string,
-  annotations: Annotation[]
+  annotations: Annotation[],
+  conclusion: string
 ): Promise<void> {
   const pullRequest = github.context.payload.pull_request;
   const head_sha = pullRequest?.head.sha ?? github.context.sha;
   const status = "completed";
-  const failures = annotations.filter((a) => {
-    return a.annotation_level === "failure";
-  });
-  const conclusion = failures.length > 0 ? "failure" : "success";
   const title = `${annotations.length} result(s) found by grep`;
   const summary = "";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import * as glob from "@actions/glob";
 import { Reporter } from "./reporter";
 import type { Pattern } from "./config";
 import * as config from "./config";
+import type { AnnotationLevel } from "./github";
 import * as github from "./github";
 import { grep } from "./grep";
 
@@ -43,6 +44,9 @@ async function run() {
     const createNewCheck = core.getBooleanInput("create-new-check", {
       required: true,
     });
+    const failureThreshold = core.getInput("failure-threshold", {
+      required: true,
+    }) as AnnotationLevel;
 
     core.info(
       `patterns: [${patterns.map((p) => p.pattern.toString()).join(", ")}]`
@@ -60,7 +64,7 @@ async function run() {
       core.info(`Fetched ${changedFiles.length} changed file(s)`);
     }
 
-    const reporter = new Reporter(createNewCheck);
+    const reporter = new Reporter(createNewCheck, failureThreshold);
 
     for (const pattern of patterns) {
       const files = await getFiles(onlyChanged, changedFiles, pattern);

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,10 +37,12 @@ async function run() {
     const patterns = config.loadPatterns(
       core.getInput("patterns", { required: true })
     );
-    const onlyChanged =
-      core.getInput("only-changed", { required: true }).toUpperCase() == "TRUE";
-    const createNewCheck =
-      core.getInput("create-new-check", { required: true }).toUpperCase() == "TRUE";
+    const onlyChanged = core.getBooleanInput("only-changed", {
+      required: true,
+    });
+    const createNewCheck = core.getBooleanInput("create-new-check", {
+      required: true,
+    });
 
     core.info(
       `patterns: [${patterns.map((p) => p.pattern.toString()).join(", ")}]`

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,8 @@ async function run() {
     );
     const onlyChanged =
       core.getInput("only-changed", { required: true }).toUpperCase() == "TRUE";
+    const createNewCheck =
+      core.getInput("create-new-check", { required: true }).toUpperCase() == "TRUE";
 
     core.info(
       `patterns: [${patterns.map((p) => p.pattern.toString()).join(", ")}]`

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -1,0 +1,9 @@
+import { Reporter } from "./reporter";
+
+test("exceedsFailureThreshold", () => {
+  const reporter = new Reporter(false, "warning");
+
+  expect(reporter.exceedsFailureThreshold("notice")).toBe(false);
+  expect(reporter.exceedsFailureThreshold("warning")).toBe(true);
+  expect(reporter.exceedsFailureThreshold("failure")).toBe(true);
+});

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,0 +1,50 @@
+import * as core from "@actions/core";
+import * as gh from "@actions/github";
+
+import type { Annotation } from "./github";
+import * as github from "./github";
+import type { GrepResult } from "./grep";
+import type { Pattern } from "./config";
+
+type ClientType = ReturnType<typeof gh.getOctokit>;
+
+export class Reporter {
+  annotations: Annotation[];
+  conclusion: string;
+
+  constructor() {
+    this.annotations = [];
+    this.conclusion = "success";
+  }
+
+  onResult(pattern: Pattern, result: GrepResult): void {
+    const annotation = {
+      path: result.path,
+      start_line: result.line,
+      end_line: result.line,
+      annotation_level: pattern.level,
+      message: pattern.message || "Flagged in freckle/grep-action",
+      title: pattern.title || "",
+      raw_details: result.input,
+    };
+
+    if (annotation.annotation_level == "failure") {
+      this.conclusion = "failure";
+    }
+
+    this.annotations.push(annotation);
+    }
+  }
+
+  async onFinish(client: ClientType): Promise<void> {
+    core.info(
+      `Creating Check result with ${this.annotations.length} annotation(s)`
+    );
+    return await github.createCheck(
+      client,
+      "Grep results",
+      this.annotations,
+      this.conclusion
+    );
+  }
+}


### PR DESCRIPTION
By-commit review is recommended.

### [Extract Reporter class](https://github.com/freckle/grep-action/pull/11/commits/50fe512b2f42c53bfba2e662eb211b0e9d49bac2)
[50fe512](https://github.com/freckle/grep-action/pull/11/commits/50fe512b2f42c53bfba2e662eb211b0e9d49bac2)

This isolates how annotations are created for each result and reported
at the end, which we're about to work on.

### [Make creation of a new check opt-in](https://github.com/freckle/grep-action/pull/11/commits/f94eff83ca94f735454dd3ae4c5e7e4a2b763da0)
[f94eff8](https://github.com/freckle/grep-action/pull/11/commits/f94eff83ca94f735454dd3ae4c5e7e4a2b763da0)

This made sense when this action was first created, but there's no need
to create a new check these days and the new check gets grouped under
the wrong workflow when done this way, which constantly confuses users.

### [Stop reimplementing core.getBooleanInput](https://github.com/freckle/grep-action/pull/11/commits/7dec4680c6c5e51946f35a1ee4062d01f87af3db)
[7dec468](https://github.com/freckle/grep-action/pull/11/commits/7dec4680c6c5e51946f35a1ee4062d01f87af3db)

### [Run v2.5 prettier in Restyled](https://github.com/freckle/grep-action/pull/11/commits/a381e93c32b8e48825c3439175f0eef0c27e969d)
[a381e93](https://github.com/freckle/grep-action/pull/11/commits/a381e93c32b8e48825c3439175f0eef0c27e969d)

Makes it match the version used locally, as per `package.json`.

### [Build](https://github.com/freckle/grep-action/pull/11/commits/521ada9f865035865d382660edded7690b9e9897)