### PR TITLE
docs: add security recommendations for SHA pinning and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ jobs:
                 A longer message body
 ```
 
+## Security Recommendations
+
+For enhanced security when using this action, consider implementing these best practices:
+
+### SHA Pinning
+
+Reference the action using a full commit SHA instead of a version tag to protect against supply chain attacks:
+
+```yaml
+- uses: freckle/grep-action@dd64f200665b77673185885bd2ef9e72bbd9ecd9  # v1.1.2
+```
+
+### Minimal Permissions
+
+Restrict the workflow permissions to only what is needed:
+
+```yaml
+permissions:
+  contents: read       # Only need to read repository contents
+  pull-requests: write # Needed to add annotations to PRs
+```
+
+These permissions ensure the action has only the necessary access to your repository while still being able to create annotations.
+
 ## Inputs
 
 - `patterns`: See below.


### PR DESCRIPTION
This PR adds a new 'Security Recommendations' section to the README that covers two important security best practices: 1) SHA Pinning - Using full commit SHAs instead of version tags to protect against supply chain attacks; 2) Minimal Permissions - Restricting workflow permissions to only what's necessary.