### PR TITLE
feat: set pattern-specific outputs

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - id: grep
+        uses: ./
         with:
           patterns: |
-            - pattern: "\\<setFailed\\>"
+            - id: set-failed
+              pattern: "\\<setFailed\\>"
 
               # Must be basic|extended|fixed|perl
               syntax: basic
@@ -47,3 +49,16 @@ jobs:
               title: "Minimal configuration test"
 
           only-changed: false
+
+      - run: |
+          # show set-failed outputs
+          echo 'set-failed: ${{ steps.grep.outputs.set-failed }}'
+
+          echo
+          echo 'set-failed_count: ${{ steps.grep.outputs.set-failed_count }}'
+
+          echo
+          echo 'set-failed_results:'
+          jq <<'EOM'
+          ${{ steps.grep.outputs.set-failed_results }}
+          EOM

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ See [`./action.yml`](./action.yml) for complete details.
 The `patterns` input is a String (as all inputs must be) that contains a Yaml
 Array of Objects with the following keys:
 
+- `id`
+
+  An optional identifier for the pattern. If provided, we will set outputs for
+  it (see below).
+
 - `pattern`
 
   A `grep` "Basic Regular Expression". See the "Basic vs Extended Regular
@@ -132,7 +137,15 @@ Array of Objects with the following keys:
 
 ## Outputs
 
-None.
+For any patterns with an `id` specified, the following outputs will be set:
+
+- `{id}`: the string `'true'` if any matches were found, or `'false'` if not.
+- `{id}_count`: the number of matches found.
+- `{id}_results`: a JSON-encoded list of objects with the following properties:
+
+  - `input`: the full line of `grep -n` output
+  - `path`: the matched path, parsed from above
+  - `line`: the line number of the match, parsed from above
 
 ## Example
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,11 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[jt]sx?$": "ts-jest",
+  },
+  transformIgnorePatterns: [
+    "/node_modules/(?!(minimatch|brace-expansion|balanced-match)/)",
+  ],
 };

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -14,6 +14,7 @@ test("Loads minimal Patterns", () => {
 
   expect(results).toEqual([
     {
+      id: null,
       pattern: "abc",
       syntax: "basic",
       binaryFiles: "binary",
@@ -24,6 +25,7 @@ test("Loads minimal Patterns", () => {
       message: null,
     },
     {
+      id: null,
       pattern: "xyz",
       syntax: "basic",
       binaryFiles: "binary",
@@ -107,6 +109,7 @@ test("Respects level", () => {
 
 test("matchesAny", () => {
   const pattern = {
+    id: null,
     pattern: "",
     syntax: "basic" as GrepSyntax,
     binaryFiles: "binary" as GrepBinaryFiles,

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import type { AnnotationLevel } from "./github";
 import type { GrepSyntax, GrepBinaryFiles } from "./grep";
 
 export type Pattern = {
+  id: string | null;
   pattern: string;
   syntax: GrepSyntax;
   binaryFiles: GrepBinaryFiles;
@@ -16,11 +17,12 @@ export type Pattern = {
 };
 
 function fromPatternYaml(patternYaml: PatternYaml): Pattern {
-  const { pattern, syntax, paths, level, title, message } = patternYaml;
+  const { id, pattern, syntax, paths, level, title, message } = patternYaml;
   const pathsIgnore = patternYaml["paths-ignore"];
   const binaryFiles = patternYaml["binary-files"];
 
   return {
+    id: id === undefined ? null : id,
     pattern,
     syntax: syntax || "basic",
     binaryFiles: binaryFiles || "binary",
@@ -33,6 +35,7 @@ function fromPatternYaml(patternYaml: PatternYaml): Pattern {
 }
 
 type PatternYaml = {
+  id: string | null;
   pattern: string;
   syntax: GrepSyntax | null;
   "binary-files": GrepBinaryFiles | null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { grep } from "./grep";
 async function getFiles(
   onlyChanged: boolean,
   changedFiles: string[],
-  pattern: Pattern
+  pattern: Pattern,
 ): Promise<string[]> {
   if (onlyChanged) {
     return changedFiles.filter((file) => {
@@ -36,7 +36,7 @@ async function run() {
 
     const token = core.getInput("github-token", { required: true });
     const patterns = config.loadPatterns(
-      core.getInput("patterns", { required: true })
+      core.getInput("patterns", { required: true }),
     );
     const onlyChanged = core.getBooleanInput("only-changed", {
       required: true,
@@ -49,7 +49,7 @@ async function run() {
     }) as AnnotationLevel;
 
     core.info(
-      `patterns: [${patterns.map((p) => p.pattern.toString()).join(", ")}]`
+      `patterns: [${patterns.map((p) => p.pattern.toString()).join(", ")}]`,
     );
     core.info(`only-changed: ${onlyChanged}`);
     core.endGroup();

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,12 @@ async function run() {
           reporter.onResult(pattern, result);
         });
         core.endGroup();
+
+        if (pattern.id) {
+          core.setOutput(pattern.id, results.length > 0 ? "true" : "false");
+          core.setOutput(`${pattern.id}_count`, results.length.toString());
+          core.setOutput(`${pattern.id}_results`, JSON.stringify(results));
+        }
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "removeComments": true,
     "module": "NodeNext",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "isolatedModules": true
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/**/*.test.ts"]


### PR DESCRIPTION
If a pattern is given an `id`, we will set a few outputs for it:

- `{id}`: `'true'` if matched
- `{id}_count`: number of matching results
- `{id}_results`: the JSONified results